### PR TITLE
Fix the passing of the input ref through props

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ export class KeycodeInput extends Component {
     numeric: PropTypes.bool,
     value: PropTypes.string,
     style: PropTypes.any,
-    ref: PropTypes.func
+    inputRef: PropTypes.func
   }
 
   static defaultProps = {
@@ -123,8 +123,8 @@ export class KeycodeInput extends Component {
         <TextInput
           ref={(component) => {
             this.input = component
-            if (this.props.ref) {
-              this.props.ref(component)
+            if (this.props.inputRef) {
+              this.props.inputRef(component)
             }
           }}
           style={[styles.input, {color: this.props.textColor}]}


### PR DESCRIPTION
As described on https://reactjs.org/docs/forwarding-refs.html, ref does not act like a normal prop, and cannot be passed as it currently is. The easiest and least breaking change is to rename it to inputRef, which is what this PR does.