### PR TITLE
Apply textColor prop to the boxes instead of the TextInput

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ export class KeycodeInput extends Component {
 
       elements.push(
         <View style={styles.box} key={i}>
-          <Text style={styles.text}>{vals[i] || ''}</Text>
+          <Text style={[styles.text, { color: this.props.textColor }]}>{vals[i] || ''}</Text>
           <View style={barStyles}/>
         </View>
       )
@@ -127,7 +127,7 @@ export class KeycodeInput extends Component {
               this.props.inputRef(component)
             }
           }}
-          style={[styles.input, {color: this.props.textColor}]}
+          style={styles.input}
           autoFocus={this.props.autoFocus}
           autoCorrect={false}
           autoCapitalize='characters'

--- a/index.js
+++ b/index.js
@@ -49,7 +49,6 @@ export class KeycodeInput extends Component {
   }
 
   async componentWillReceiveProps (nextProps) {
-    console.log(nextProps)
     if ('value' in nextProps && nextProps.value !== this.state.value) {
       await this._setValue(nextProps.value)
     }


### PR DESCRIPTION
Solve this https://github.com/includable/react-native-keycode/issues/1, tested on iOS with RN 0.57.8

P.S. The package.json version(1.0.3) is not aligned with npm(1.0.4)